### PR TITLE
Fixed craftcms/cms requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "craftcms/cms": "~3.0.0-beta.20"
+    "craftcms/cms": "^3.0.0-beta.20"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Without this change, the plugin is saying it won’t be compatible with Craft 3.1+, which probably isn’t want you intended.